### PR TITLE
Fix Prerun Spec.

### DIFF
--- a/test/ubuntu/testcase.d/spec/localhost/00_prerun_spec.rb
+++ b/test/ubuntu/testcase.d/spec/localhost/00_prerun_spec.rb
@@ -20,12 +20,12 @@ describe 'It should be in a clean state before starting any tests' do
 
   describe 'We should have wire installed' do
     describe command 'which wire' do
-      it { should return_exitstatus(0)) }
+      its(:exit_status) { should eq 0 }
       it { should return_stdout('/usr/local/bin/wire') }
     end
 
-    describe command 'gem list --local wire' do
-      its(:stdout) { should match /wire/ }
+    describe command 'gem list --local dewiring' do
+      its(:stdout) { should match /dewiring/ }
     end
   end
 end


### PR DESCRIPTION
- Gem installed is called dewiring now, not wire.
- Use working syntax for serverspec return code test.
