### PR TITLE
Tune dnsmasq to be dhcp authoriative.

### DIFF
--- a/test/ubuntu/provision.d/05_network
+++ b/test/ubuntu/provision.d/05_network
@@ -6,3 +6,7 @@ sudo apt-get install -yqq openvswitch-common openvswitch-switch openvswitch-test
 echo == Install dnsmasq
 sudo apt-get install -yqq dnsmasq
 
+echo == Tune dhcp setup. Be authoritative.
+sed -i s/^#dhcp-authoritative/dhcp-authoritative/ /etc/dnsmasq.conf
+
+


### PR DESCRIPTION
Only for ubuntu test vagrant box: By setting dnsmasq into authorative mode, DHCPREQUESTs are quickly answered with DHCPNAK. This reduces DHCP config time by 5 seconds.
